### PR TITLE
Provision a heroku box on the fly

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,6 +6,7 @@ require('isomorphic-fetch');
 var program = require('commander');
 var deploy = require('../tasks/deploy');
 var clean = require('../tasks/clean');
+var provision = require('../tasks/provision');
 
 function exit(err) {
 	console.log(err);
@@ -27,5 +28,10 @@ program
 		deploy().catch(exit);
 	});
 
+program
+	.command('provision')
+	.action(function() {
+		provision();
+	});
 
 program.parse(process.argv);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -31,7 +31,7 @@ program
 program
 	.command('provision')
 	.action(function() {
-		provision();
+		provision().then(function () { console.log(arguments) }).catch(exit);
 	});
 
 program.parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
   "version": "1.3.2",
   "dependencies": {
     "commander": "^2.6.0",
+    "debug": "^2.1.1",
     "denodeify": "^1.2.0",
     "es6-promise": "^2.0.1",
     "haikro": "^1.9.0",
+    "heroku-client": "^1.9.1",
     "isomorphic-fetch": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "debug": "^2.1.1",
     "denodeify": "^1.2.0",
     "es6-promise": "^2.0.1",
-    "haikro": "^1.9.0",
+    "haikro": "^1.12.0",
     "heroku-client": "^1.9.1",
     "isomorphic-fetch": "^1.1.0"
   }

--- a/tasks/provision.js
+++ b/tasks/provision.js
@@ -1,0 +1,32 @@
+
+var util   = require('util'),
+    Heroku = require('heroku-client')
+    debug  = require('debug')('next-build-tools');
+
+// create a Heroku application server
+module.exports = function () {
+
+    var build = process.env.CI_BUILD_NUMBER;
+    var branch = process.env.CI_BRANCH;
+    var project = process.env.PROJECT;
+    var heroku_auth = process.env.HEROKU_API_TOKEN;
+
+    if (!project || !branch || !build || !heroku_auth) {
+        throw "You need to set HEROKU_API_TOKEN, PROJECT, CI_BRANCH, and CI_BUILD_NUMBER environment variables";
+    }
+
+    var server = {
+        name: util.format('%s-%s-%s', project, branch, build),
+        region: 'eu',
+        organization: 'financial-times'
+    }
+
+    var heroku = new Heroku({ token: heroku_auth });
+    heroku.organizations().apps().create(server, function (err, app) {
+        if (err) {
+            throw new Error(err);
+        }
+        debug('Successfully created app', app);
+    });
+
+};

--- a/tasks/provision.js
+++ b/tasks/provision.js
@@ -1,7 +1,11 @@
 
-var util   = require('util'),
-    Heroku = require('heroku-client')
-    debug  = require('debug')('next-build-tools');
+var util   = require('util');
+var debug  = require('debug')('next-build-tools');
+var packageJson = require(process.cwd() + '/package.json');
+var denodeify = require('denodeify');
+var exec = denodeify(require('child_process').exec, function(err, stdout, stderr) { return [err, stdout]; });
+var create = require('haikro/lib/create');
+var logger = require('haikro/lib/logger');
 
 // create a Heroku application server
 module.exports = function () {
@@ -15,18 +19,54 @@ module.exports = function () {
         throw "You need to set HEROKU_API_TOKEN, PROJECT, CI_BRANCH, and CI_BUILD_NUMBER environment variables";
     }
 
-    var server = {
-        name: util.format('%s-%s-%s', project, branch, build),
-        region: 'eu',
-        organization: 'financial-times'
-    }
-
-    var heroku = new Heroku({ token: heroku_auth });
-    heroku.organizations().apps().create(server, function (err, app) {
-        if (err) {
-            throw new Error(err);
-        }
-        debug('Successfully created app', app);
-    });
-
+	var token;
+	return Promise.all([
+		process.env.HEROKU_AUTH_TOKEN ? Promise.resolve(process.env.HEROKU_AUTH_TOKEN) : exec('heroku auth:token'),
+	])
+		.then(function(results) {
+	        logger.setLevel('debug');
+			token = results[0].trim();
+            var server = {
+                app: util.format('%s-%s-%s', project, branch, build),
+                region: 'eu',
+				token: token,
+                organization: 'financial-times'
+            }
+            return create(server);
+		});
 };
+
+/*
+function normalizeName(name) {
+	var matches = name.match(/^(?:ft-)?(?:next-)?(.*)/);
+	if (matches) {
+		return matches[1];
+	}
+	return name;
+}
+
+module.exports = function() {
+	logger.setLevel('debug');
+	var token;
+	var commit;
+	return Promise.all([
+		process.env.HEROKU_AUTH_TOKEN ? Promise.resolve(process.env.HEROKU_AUTH_TOKEN) : exec('heroku auth:token'),
+		exec('git rev-parse HEAD'),
+		exec('npm prune --production')
+	])
+		.then(function(results) {
+			token = results[0];
+			commit = results[1];
+			return build({ project: process.cwd() });
+		})
+		.then(function() {
+			var name = 'ft-next-' + normalizeName(packageJson.name);
+			console.log('Next Build Tools going to deploy to ' + name);
+			return deploy({
+				app: name,
+				token: token,
+				project: process.cwd(),
+				commit: commit
+			});
+		});
+};*/

--- a/tasks/provision.js
+++ b/tasks/provision.js
@@ -39,7 +39,7 @@ module.exports = function () {
                 region: 'eu',
 				token: token,
                 organization: 'financial-times'
-            }
+            };
             return create(server);
 		});
 };

--- a/tasks/provision.js
+++ b/tasks/provision.js
@@ -7,16 +7,23 @@ var exec = denodeify(require('child_process').exec, function(err, stdout, stderr
 var create = require('haikro/lib/create');
 var logger = require('haikro/lib/logger');
 
+function normalizeName(name) {
+	var matches = name.match(/^(?:ft-)?(?:next-)?(.*)/);
+	if (matches) {
+		return matches[1];
+	}
+	return name;
+}
+
 // create a Heroku application server
 module.exports = function () {
 
     var build = process.env.CI_BUILD_NUMBER;
     var branch = process.env.CI_BRANCH;
-    var project = process.env.PROJECT;
     var heroku_auth = process.env.HEROKU_API_TOKEN;
 
-    if (!project || !branch || !build || !heroku_auth) {
-        throw "You need to set HEROKU_API_TOKEN, PROJECT, CI_BRANCH, and CI_BUILD_NUMBER environment variables";
+    if (!branch || !build || !heroku_auth) {
+        throw "You need to set HEROKU_API_TOKEN, CI_BRANCH, and CI_BUILD_NUMBER environment variables";
     }
 
 	var token;
@@ -26,6 +33,7 @@ module.exports = function () {
 		.then(function(results) {
 	        logger.setLevel('debug');
 			token = results[0].trim();
+			var project = 'ft-next-' + normalizeName(packageJson.name);
             var server = {
                 app: util.format('%s-%s-%s', project, branch, build),
                 region: 'eu',
@@ -35,38 +43,3 @@ module.exports = function () {
             return create(server);
 		});
 };
-
-/*
-function normalizeName(name) {
-	var matches = name.match(/^(?:ft-)?(?:next-)?(.*)/);
-	if (matches) {
-		return matches[1];
-	}
-	return name;
-}
-
-module.exports = function() {
-	logger.setLevel('debug');
-	var token;
-	var commit;
-	return Promise.all([
-		process.env.HEROKU_AUTH_TOKEN ? Promise.resolve(process.env.HEROKU_AUTH_TOKEN) : exec('heroku auth:token'),
-		exec('git rev-parse HEAD'),
-		exec('npm prune --production')
-	])
-		.then(function(results) {
-			token = results[0];
-			commit = results[1];
-			return build({ project: process.cwd() });
-		})
-		.then(function() {
-			var name = 'ft-next-' + normalizeName(packageJson.name);
-			console.log('Next Build Tools going to deploy to ' + name);
-			return deploy({
-				app: name,
-				token: token,
-				project: process.cwd(),
-				commit: commit
-			});
-		});
-};*/


### PR DESCRIPTION
Uses [codeship env variables](https://codeship.com/documentation/continuous-integration/set-environment-variables/) and the [heroku api](https://github.com/heroku/node-heroku-client) to provision an environment ready for deployment.

I've gone with `<project>-<branch>-<build-number>` as a convention.

todo - 

- Tweak deployment to use this convention, Eg. make deploy --app ft-next-engels-foo-1
- Tell the night-watch smoke test to use this convention.
- Write a teardown script to happen on branch merge/deletion.


/cc @matthew-andrews might need you advice/help with the deployment tweak.