### PR TITLE
Enforce usage of next-config-vars service by breaking deploys if not used

### DIFF
--- a/bin/next-build-tools.js
+++ b/bin/next-build-tools.js
@@ -29,7 +29,11 @@ program
 		.command('deploy [app]')
 		.description('runs haikro deployment scripts with sensible defaults for Next projects')
 		.action(function(app) {
-			deploy(app).catch(exit);
+			configure({ source: app })
+				.then(function() {
+					return deploy(app);
+				})
+				.catch(exit);
 		});
 
 	program


### PR DESCRIPTION
Up to you @commuterjoy (& team).  I had this in before but took it out because I didn't want to disrupt people.