### PR TITLE
Allow config to be overridden on the fly

### DIFF
--- a/bin/next-build-tools.js
+++ b/bin/next-build-tools.js
@@ -11,6 +11,10 @@ var configure = require('../tasks/configure');
 var provision = require('../tasks/provision');
 var downloadConfiguration = require('../tasks/download-configuration');
 
+function list(val) {
+  return val.split(',');
+}
+
 function exit(err) {
 	console.log(err);
 	process.exit(1);
@@ -35,8 +39,9 @@ program
 	program
 		.command('configure [source] [target]')
 		.description('downloads environment variables from next-config-vars and uploads them to the current app')
-		.action(function(source, target) {
-			configure({ source: source, target: target }).catch(exit);
+		.option('-o, --overrides <abc>', 'override these values', list)
+		.action(function(source, target, options) {
+			configure({ source: source, target: target, overrides: options.overrides }).catch(exit);
 		});
 
 	program

--- a/tasks/configure.js
+++ b/tasks/configure.js
@@ -14,7 +14,7 @@ module.exports = function(opts) {
 	if (opts.overrides) { 
 		opts.overrides.map(function (o) {
 			var t = o.split('=');
-			overrides[t[0]] = t[1]
+			overrides[t[0]] = t[1];
 		});
 	}
 
@@ -71,7 +71,7 @@ module.exports = function(opts) {
 				}
 			});
 			
-			console.log("Setting environment to", patch)
+			console.log("Setting environment to", patch);
 			
 			return fetch('https://api.heroku.com/apps/' + target + '/config-vars', {
 				headers: authorizedPostHeaders,

--- a/tasks/configure.js
+++ b/tasks/configure.js
@@ -9,11 +9,20 @@ module.exports = function(opts) {
 	
 	var source = opts.source || 'ft-next-' + normalizeName(packageJson.name);
 	var target = opts.target || source;
+	var overrides = {};
+
+	if (opts.overrides) { 
+		opts.overrides.map(function (o) {
+			var t = o.split('=');
+			overrides[t[0]] = t[1]
+		});
+	}
 
 	var authorizedPostHeaders = {
 		'Accept': 'application/vnd.heroku+json; version=3',
 		'Content-Type': 'application/json'
 	};
+
 	return herokuAuthToken()
 		.then(function(token) {
 			authorizedPostHeaders.Authorization = 'Bearer ' + token;
@@ -45,8 +54,13 @@ module.exports = function(opts) {
 			Object.keys(current).forEach(function(key) {
 				patch[key] = null;
 			});
+
 			Object.keys(desired).forEach(function(key) {
 				patch[key] = desired[key];
+			});
+			
+			Object.keys(overrides).forEach(function(key) {
+				patch[key] = overrides[key];
 			});
 
 			Object.keys(patch).forEach(function(key) {
@@ -56,7 +70,9 @@ module.exports = function(opts) {
 					console.log("Setting config var: " + key);
 				}
 			});
-
+			
+			console.log("Setting environment to", patch)
+			
 			return fetch('https://api.heroku.com/apps/' + target + '/config-vars', {
 				headers: authorizedPostHeaders,
 				method: 'patch',


### PR DESCRIPTION
When copying config we want to overwrite the odd value. In this case we don't want feature branch builds behaving as production boxes. (I think) For example, do we want these branches logging to Graphite?

```
next-build-tools configure ft-next-engels ft-next-engels-4014692 \
    --overrides "NODE_ENV=branch,DEBUG=*"
```