### PR TITLE
Add --skip-gtg flag to deploy task

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
   Commands:
 
-    deploy [app]                                        runs haikro deployment scripts with sensible defaults for Next projects
+    deploy [options] [app]                              runs haikro deployment scripts with sensible defaults for Next projects
     configure [options] [source] [target]               downloads environment variables from next-config-vars and uploads them to the current app
     scale [source] [target]                             downloads process information from next-service-registry and scales/sizes the application servers
     provision [app]                                     provisions a new instance of an application server

--- a/bin/next-build-tools.js
+++ b/bin/next-build-tools.js
@@ -38,7 +38,7 @@ program
 	.action(function(app, options) {
 		deploy({
 			app: app,
-			gtg: options.skipGtg
+			skipGtg: options.skipGtg
 		}).catch(exit);
 	});
 

--- a/bin/next-build-tools.js
+++ b/bin/next-build-tools.js
@@ -34,8 +34,12 @@ program.version(require('../package.json').version);
 program
 	.command('deploy [app]')
 	.description('runs haikro deployment scripts with sensible defaults for Next projects')
-	.action(function(app) {
-		deploy(app).catch(exit);
+	.option('-s, --skip-gtg', 'skip the good-to-go HTTP check')
+	.action(function(app, options) {
+		deploy({
+			app: app,
+			gtg: options.skipGtg
+		}).catch(exit);
 	});
 
 program

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -43,7 +43,7 @@ module.exports = function(opts) {
 
 		// Start polling
 		.then(function() {
-			if(!opts.gtg) {
+			if(!opts.skipGtg) {
 				return new Promise(function(resolve, reject) {
 					var timeout;
 					var checker;


### PR DESCRIPTION
Simply adds a flag `--skip-gtg` to the deploy task which in turn skips the good-to-go checks. This is for use cases where an app doesn't expose any HTTP endpoints, such as worker processes.

/cc @matthew-andrews @wheresrhys 