### PR TITLE
Fail the build when the build fails

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -38,57 +38,45 @@ function run(task, opts) {
 }
 
 gulp.task('build-sass', function() {
-	return new Promise(function(resolve, reject) {
-		obt.build.sass(gulp, {
-				sass: sourceFolder + mainScssFile,
-				buildFolder: buildFolder,
-				env: isDev ? 'development' : 'production'
-			})
-			.on('end', function() {
-				console.log('build-sass completed');
-				resolve();
-			})
-			.on('error', function() {
-				console.warn('build-sass errored');
-				reject();
-			});
-	});
+	return obt.build.sass(gulp, {
+			sass: sourceFolder + mainScssFile,
+			buildFolder: buildFolder,
+			env: isDev ? 'development' : 'production'
+		})
+		.on('end', function () {
+			console.log('build-sass completed');
+		})
+		.on('error', function () {
+			console.warn('build-sass errored');
+		});
 });
 
 gulp.task('build-js', function() {
-	return new Promise(function(resolve, reject) {
-		return obt.build.js(gulp, {
-				js: sourceFolder + mainJsFile,
-				buildFolder: buildFolder,
-				env: 'development' // need to run as development as we do our own sourcemaps
-			})
-			.on('end', function() {
-				console.log('build-js completed');
-				resolve();
-			})
-			.on('error', function() {
-				console.warn('build-js errored');
-				reject();
-			});
-	});
+	return obt.build.js(gulp, {
+			js: sourceFolder + mainJsFile,
+			buildFolder: buildFolder,
+			env: 'development' // need to run as development as we do our own sourcemaps
+		})
+		.on('end', function () {
+			console.log('build-js completed');
+		})
+		.on('error', function () {
+			console.warn('build-js errored');
+		});
 });
 
 gulp.task('build-minify-js', ['build-js'], function() {
-	return new Promise(function(resolve, reject) {
-		var app = normalizeName(packageJson.name, { version: false });
-		return gulp.src(buildFolder + mainJsFile)
-			.pipe(extractSourceMap({ saveTo: buildFolder + mainJsSourceMapFile }))
-			.pipe(minify({ sourceMapIn: buildFolder + mainJsSourceMapFile, sourceMapOut: '/' + app + '/' + mainJsSourceMapFile }))
-			.pipe(gulp.dest(buildFolder))
-			.on('end', function() {
-				console.log('build-minify-js completed');
-				resolve();
-			})
-			.on('error', function () {
-				console.log('build-minify-js errored');
-				reject();
-			});
-	});
+	var app = normalizeName(packageJson.name, { version: false });
+	return gulp.src(buildFolder + mainJsFile)
+		.pipe(extractSourceMap({ saveTo: buildFolder + mainJsSourceMapFile }))
+		.pipe(minify({ sourceMapIn: buildFolder + mainJsSourceMapFile, sourceMapOut: '/' + app + '/' + mainJsSourceMapFile }))
+		.pipe(gulp.dest(buildFolder))
+		.on('end', function () {
+			console.log('build-minify-js completed');
+		})
+		.on('error', function () {
+			console.log('build-minify-js errored');
+		});
 });
 
 module.exports = function(opts) {

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -44,11 +44,12 @@ gulp.task('build-sass', function() {
 			buildFolder: buildFolder,
 			env: isDev ? 'development' : 'production'
 		})
-		.on('end', function () {
+		.on('end', function() {
 			console.log('build-sass completed');
 		})
-		.on('error', function () {
+		.on('error', function(err) {
 			console.warn('build-sass errored');
+			throw err;
 		});
 });
 
@@ -58,11 +59,12 @@ gulp.task('build-js', function() {
 			buildFolder: buildFolder,
 			env: 'development' // need to run as development as we do our own sourcemaps
 		})
-		.on('end', function () {
+		.on('end', function() {
 			console.log('build-js completed');
 		})
-		.on('error', function () {
+		.on('error', function() {
 			console.warn('build-js errored');
+			throw err;
 		});
 });
 
@@ -72,11 +74,12 @@ gulp.task('build-minify-js', ['build-js'], function() {
 		.pipe(extractSourceMap({ saveTo: buildFolder + mainJsSourceMapFile }))
 		.pipe(minify({ sourceMapIn: buildFolder + mainJsSourceMapFile, sourceMapOut: '/' + app + '/' + mainJsSourceMapFile }))
 		.pipe(gulp.dest(buildFolder))
-		.on('end', function () {
+		.on('end', function() {
 			console.log('build-minify-js completed');
 		})
-		.on('error', function () {
+		.on('error', function() {
 			console.log('build-minify-js errored');
+			throw err;
 		});
 });
 

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -38,45 +38,57 @@ function run(task, opts) {
 }
 
 gulp.task('build-sass', function() {
-	return obt.build.sass(gulp, {
-			sass: sourceFolder + mainScssFile,
-			buildFolder: buildFolder,
-			env: isDev ? 'development' : 'production'
-		})
-		.on('end', function () {
-			console.log('build-sass completed');
-		})
-		.on('error', function () {
-			console.warn('build-sass errored');
-		});
+	return new Promise(function(resolve, reject) {
+		obt.build.sass(gulp, {
+				sass: sourceFolder + mainScssFile,
+				buildFolder: buildFolder,
+				env: isDev ? 'development' : 'production'
+			})
+			.on('end', function() {
+				console.log('build-sass completed');
+				resolve();
+			})
+			.on('error', function() {
+				console.warn('build-sass errored');
+				reject();
+			});
+	});
 });
 
 gulp.task('build-js', function() {
-	return obt.build.js(gulp, {
-			js: sourceFolder + mainJsFile,
-			buildFolder: buildFolder,
-			env: 'development' // need to run as development as we do our own sourcemaps
-		})
-		.on('end', function () {
-			console.log('build-js completed');
-		})
-		.on('error', function () {
-			console.warn('build-js errored');
-		});
+	return new Promise(function(resolve, reject) {
+		return obt.build.js(gulp, {
+				js: sourceFolder + mainJsFile,
+				buildFolder: buildFolder,
+				env: 'development' // need to run as development as we do our own sourcemaps
+			})
+			.on('end', function() {
+				console.log('build-js completed');
+				resolve();
+			})
+			.on('error', function() {
+				console.warn('build-js errored');
+				reject();
+			});
+	});
 });
 
 gulp.task('build-minify-js', ['build-js'], function() {
-	var app = normalizeName(packageJson.name, { version: false });
-	return gulp.src(buildFolder + mainJsFile)
-		.pipe(extractSourceMap({ saveTo: buildFolder + mainJsSourceMapFile }))
-		.pipe(minify({ sourceMapIn: buildFolder + mainJsSourceMapFile, sourceMapOut: '/' + app + '/' + mainJsSourceMapFile }))
-		.pipe(gulp.dest(buildFolder))
-		.on('end', function () {
-			console.log('build-minify-js completed');
-		})
-		.on('error', function () {
-			console.log('build-minify-js errored');
-		});
+	return new Promise(function(resolve, reject) {
+		var app = normalizeName(packageJson.name, { version: false });
+		return gulp.src(buildFolder + mainJsFile)
+			.pipe(extractSourceMap({ saveTo: buildFolder + mainJsSourceMapFile }))
+			.pipe(minify({ sourceMapIn: buildFolder + mainJsSourceMapFile, sourceMapOut: '/' + app + '/' + mainJsSourceMapFile }))
+			.pipe(gulp.dest(buildFolder))
+			.on('end', function() {
+				console.log('build-minify-js completed');
+				resolve();
+			})
+			.on('error', function () {
+				console.log('build-minify-js errored');
+				reject();
+			});
+	});
 });
 
 module.exports = function(opts) {

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -32,7 +32,8 @@ function run(task, opts) {
 			console.log("Watching " + getGlob(task) + " and will trigger " + task);
 			gulp.watch(getGlob(task), [task]);
 		} else {
-			gulp.start([task], resolve);
+			gulp.start([task], resolve)
+				.on('error', reject);
 		}
 	});
 }

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -62,7 +62,7 @@ gulp.task('build-js', function() {
 		.on('end', function() {
 			console.log('build-js completed');
 		})
-		.on('error', function() {
+		.on('error', function(err) {
 			console.warn('build-js errored');
 			throw err;
 		});
@@ -77,7 +77,7 @@ gulp.task('build-minify-js', ['build-js'], function() {
 		.on('end', function() {
 			console.log('build-minify-js completed');
 		})
-		.on('error', function() {
+		.on('error', function(err) {
 			console.log('build-minify-js errored');
 			throw err;
 		});


### PR DESCRIPTION
We came very very very close to breaking article today if it hadn't have been for a unit test that was checking `/public/main.css` and [image diff regressions](https://github.com/Financial-Times/next-article/pull/560) `nbt build` was not failing when the styling for an app couldn't be built.

See here:- https://travis-ci.org/Financial-Times/next-article/builds/67408615

The build errors on build of sass and merrily carries on as if nothing happened.

![screen shot 2015-06-18 at 19 18 01](https://cloud.githubusercontent.com/assets/825088/8239111/ad5a0ab4-15f1-11e5-9810-feade0427205.png)


!!