### PR TITLE
Don't silently update development keys

### DIFF
--- a/tasks/run.js
+++ b/tasks/run.js
@@ -73,7 +73,7 @@ module.exports = function (opts) {
 				.then(function() {
 
 					// Silent update — throw away any errors
-					downloadDevelopmentKeys({ update: true });
+					downloadDevelopmentKeys();
 
 					return Promise.all([
 						runLocal({ port: localPort }),


### PR DESCRIPTION
When you execute ```make run```, download-development-keys.js says the expected file "already exists so not attempting to download & overwrite". But then, run.js executes  downloadDevelopmentKeys() with update:true, which silently downloads & overwrites the file. When you're unaware of this it seems as though the first statement is a lie.

If an update _is_ mandatory, then don't merge this branch; and instead fix the confusion some other way, like maybe adding a console log here saying "Mandatory update: downloading & overwriting ~/.next-development-keys.json"