### PR TITLE
specify exact cache control for deploy static

### DIFF
--- a/bin/next-build-tools.js
+++ b/bin/next-build-tools.js
@@ -202,6 +202,7 @@ program
 	.option('--region <region>', 'Optionally set the region (default to eu-west-1)')
 	.option('--bucket <bucket>', 'Optionally set the bucket (default to ft-next-qa)')
 	.option('--no-cache', 'Optionally don\'t set a far future cache')
+	.option('--cache-control <cacheControl>', 'Optionally specify a cache control value')
 	.action(function(file, files, opts) {
 		files.unshift(file);
 		var region = opts.region || 'eu-west-1';
@@ -214,7 +215,8 @@ program
 			region: region,
 			bucket: bucket,
 			strip: opts.strip,
-			cache: opts.cache
+			cache: opts.cache,
+			cacheControl: opts.cacheControl
 		}).catch(exit);
 	});
 

--- a/tasks/deploy-static.js
+++ b/tasks/deploy-static.js
@@ -47,18 +47,18 @@ module.exports = function(opts) {
 				console.log("About to upload " + file + " to " + key);
 				return new Promise(function(resolve, reject) {
 					s3bucket.upload({
-							Key: key,
-							ContentType: determineContentType(file),
-							ACL: 'public-read',
-							Body: content,
-							CacheControl: opts.cache ? 'public, max-age=604800000' : undefined
-						}, function(err, data) {
-							if (err) {
-								reject(err);
-							} else {
-								resolve(data);
-							}
-						});
+						Key: key,
+						ContentType: determineContentType(file),
+						ACL: 'public-read',
+						Body: content,
+						CacheControl: opts.cacheControl || (opts.cache ? 'public, max-age=604800000' : undefined)
+					}, function(err, data) {
+						if (err) {
+							reject(err);
+						} else {
+							resolve(data);
+						}
+					});
 				})
 					.then(function(result) {
 						console.log("Successfully uploaded: " + key);


### PR DESCRIPTION
because amazon erases previously set cache control if new asset uploaded without cache control set @matthew-andrews 