### PR TITLE
Adding browsers to nightwatch tests

### DIFF
--- a/config/nightwatch.json
+++ b/config/nightwatch.json
@@ -24,6 +24,20 @@
         "platform": "WINDOWS"
       }
     },
+    "chrome43": {
+      "desiredCapabilities": {
+        "browserName": "chrome",
+        "version": "43.0",
+        "platform": "Windows 7"
+      }
+    },
+    "chrome42": {
+      "desiredCapabilities": {
+        "browserName": "chrome",
+        "version": "42.0",
+        "platform": "Windows 7"
+      }
+    },
     "chrome41": {
       "desiredCapabilities": {
         "browserName": "chrome",
@@ -35,6 +49,27 @@
       "desiredCapabilities": {
         "browserName": "chrome",
         "version": "40.0",
+        "platform": "Windows 7"
+      }
+    },
+    "firefox39": {
+      "desiredCapabilities": {
+        "browserName": "firefox",
+        "version": "39.0",
+        "platform": "Windows 7"
+      }
+    },
+    "firefox38": {
+      "desiredCapabilities": {
+        "browserName": "firefox",
+        "version": "38.0",
+        "platform": "Windows 7"
+      }
+    },
+    "firefox37": {
+      "desiredCapabilities": {
+        "browserName": "firefox",
+        "version": "37.0",
         "platform": "Windows 7"
       }
     },

--- a/tasks/nightwatch.js
+++ b/tasks/nightwatch.js
@@ -13,7 +13,7 @@ function toStdErr(data) {
 
 module.exports = function(opts) {
 	var test = opts.test;
-	var env = opts.env || 'ie10,firefox36,chrome41,iphone7,Android_Nexus7HD';
+	var env = opts.env || 'ie9,ie10,ie11,firefox38,firefox39,chrome42,chrome43,iphone7,Android_Nexus7HD';
 	var config = opts.config || path.join(__dirname, '..', 'config', 'nightwatch.json');
 	var args = [ '--env', env, '--test', test, '--config', config ];
 


### PR DESCRIPTION
@matthew-andrews 

SauceLabs is giving us 5 test runners instead of 3 now, and since we're spending a lot of time waiting for mobile simulators to spin up anyway, we can afford to add some more browsers without costing ourselves any additional time.

* Updating to latest chrome and firefox.
* Also adding latest-but-one for chrome and firefox, to put us inline with our official browser support policy.
* Adding ie9 and ie11.

