### PR TITLE
nbt build can build worker.js

### DIFF
--- a/bin/next-build-tools.js
+++ b/bin/next-build-tools.js
@@ -142,7 +142,7 @@ program
 	.option('--watch', 'Watches files')
 	.option('--skip-js', 'skips compilation of JavaScript')
 	.option('--skip-sass', 'skips compilation of Sass')
-	.option('--skip-worker', 'skips compilation of Service Worker JavaScript')
+	.option('--worker', 'additionally builds Service Worker JavaScript')
 	.description('build javascript and css')
 	.action(function(options) {
 		build({
@@ -150,7 +150,7 @@ program
 			watch: options.watch,
 			skipJs: options.skipJs,
 			skipSass: options.skipSass,
-			skipWorker: options.skipWorker
+			worker: options.worker
 		}).catch(exit);
 	});
 

--- a/bin/next-build-tools.js
+++ b/bin/next-build-tools.js
@@ -142,13 +142,15 @@ program
 	.option('--watch', 'Watches files')
 	.option('--skip-js', 'skips compilation of JavaScript')
 	.option('--skip-sass', 'skips compilation of Sass')
+	.option('--skip-worker', 'skips compilation of Service Worker JavaScript')
 	.description('build javascript and css')
 	.action(function(options) {
 		build({
 			isDev: options.dev,
 			watch: options.watch,
 			skipJs: options.skipJs,
-			skipSass: options.skipSass
+			skipSass: options.skipSass,
+			skipWorker: options.skipWorker
 		}).catch(exit);
 	});
 

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -67,12 +67,8 @@ function buildJs(jsFile) {
 		console.log('build-js completed for ' + jsFile);
 	})
 	.on('error', function(err) {
-		if(err.message.indexOf('Cannot find module' === 0)) {
-			console.warn('File:' + jsFile + ' does not exist. Skipping.');
-		} else {
-			console.warn('build-js errored for ' + jsFile);
-			throw err;
-		}
+		console.warn('build-js errored for ' + jsFile);
+		throw err;
 	});
 }
 
@@ -104,7 +100,6 @@ gulp.task('build-minify-js', ['build-js'], function() {
 });
 
 gulp.task('build-minify-worker', ['build-worker'], function() {
-
 	return buildMinifyJs(workerJsFile, workerJsSourceMapFile);
 });
 
@@ -117,7 +112,7 @@ module.exports = function(opts) {
 	if (!opts.skipJs) {
 		promises.push(run(opts.isDev ? 'build-js' : 'build-minify-js', opts));
 	}
-	if(!opts.skipWorker) {
+	if(opts.worker) {
 		promises.push(run(opts.isDev ? 'build-worker' : 'build-minify-worker', opts));
 	}
 	return Promise.all(promises);


### PR DESCRIPTION
/cc @matthew-andrews @phamann 

Note: no longer throwing error if file (main.js or worker.js) does not exist. This is so I can have the option as --skip-worker to be more consistent with the others...