### PR TITLE
Use Directly to throttle test-url requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "aws-sdk": "^2.1.19",
     "commander": "^2.6.0",
     "denodeify": "^1.2.0",
+    "directly": "^1.0.1",
     "es6-promise": "^2.0.1",
     "fastly": "Financial-Times/fastly#v2.5.0",
     "fetchres": "^1.0.4",

--- a/tasks/test-urls.js
+++ b/tasks/test-urls.js
@@ -42,7 +42,7 @@ function testUrls (opts) {
 				var failures = [];
 				function checkGtg() {
 					console.log('polling:' + baseUrl + url);
-					 fetch(baseUrl + url, {
+					fetch(baseUrl + url, {
 							timeout: opts.timeout || 2000,
 							headers: headers
 						})

--- a/tasks/test-urls.js
+++ b/tasks/test-urls.js
@@ -2,6 +2,7 @@
 require('array.prototype.find');
 var path = require('path');
 var normalizeName = require('../lib/normalize-name');
+var Directly = require('directly');
 var packageJson = require(process.cwd() + '/package.json');
 var appName;
 
@@ -9,7 +10,8 @@ function testUrls (opts) {
 
 	var baseUrl = 'http://' + appName + '.herokuapp.com';
 	var headers = opts.headers || {};
-	return Promise.all(Object.keys(opts.urls).map(function (url) {
+
+	var fetchers = Object.keys(opts.urls).map(function (url) {
 		var expected = opts.urls[url];
 
 		if (typeof expected === 'string') {
@@ -25,98 +27,105 @@ function testUrls (opts) {
 			expected.status = expected.status || 200;
 		}
 
-		return new Promise(function(resolve, reject) {
+		return function() {
 
-			function end(message) {
-				console.log(message);
-				clearTimeout(timeout);
-				clearInterval(checker);
-				resolve();
-			}
-			var timeout;
-			var checker;
-			var failures = [];
-			function checkGtg() {
-				console.log('polling:' + baseUrl + url);
-				fetch(baseUrl + url, {
-						timeout: opts.timeout || 2000,
-						headers: headers
-					})
-					.then(function(response) {
-						return new Promise(function (resolve, reject) {
-							if (expected.status) {
-								if (response.status !== expected.status) {
-									if (failures.indexOf('bad status: ' + response.status) === -1) {
-										failures.push('bad status: ' + response.status);
+			return new Promise(function(resolve, reject) {
+
+				function end(message) {
+					console.log(message);
+					clearTimeout(timeout);
+					clearInterval(checker);
+					resolve();
+				}
+				var timeout;
+				var checker;
+				var failures = [];
+				function checkGtg() {
+					console.log('polling:' + baseUrl + url);
+					 fetch(baseUrl + url, {
+							timeout: opts.timeout || 2000,
+							headers: headers
+						})
+						.then(function(response) {
+							return new Promise(function (resolve, reject) {
+								if (expected.status) {
+									if (response.status !== expected.status) {
+										if (failures.indexOf('bad status: ' + response.status) === -1) {
+											failures.push('bad status: ' + response.status);
+										}
+										return reject();
 									}
-									return reject();
 								}
-							}
 
-							if (expected.redirect) {
-								var arrivedAt = response.url.replace(baseUrl, '');
-								if (arrivedAt !== expected.redirect) {
-									if (failures.indexOf('bad redirect: ' + arrivedAt) === -1) {
-										failures.push('bad redirect: ' + arrivedAt);
+								if (expected.redirect) {
+									var arrivedAt = response.url.replace(baseUrl, '');
+									if (arrivedAt !== expected.redirect) {
+										if (failures.indexOf('bad redirect: ' + arrivedAt) === -1) {
+											failures.push('bad redirect: ' + arrivedAt);
+										}
+										return reject();
 									}
-									return reject();
 								}
-							}
 
-							if (expected.headers) {
-								var badHeaders = Object.keys(expected.headers).filter(function (key) {
-									return response.headers.get(key) !== expected.headers[key];
+								if (expected.headers) {
+									var badHeaders = Object.keys(expected.headers).filter(function (key) {
+										return response.headers.get(key) !== expected.headers[key];
+									});
+
+									if (badHeaders.length) {
+										badHeaders = badHeaders.map(function (header) {
+											return header + ':' + response.headers.get(header);
+										}).join('; ');
+
+										if (failures.indexOf('bad headers: ' + badHeaders) === -1) {
+											failures.push('bad headers: ' + badHeaders);
+										}
+										return reject();
+									}
+								}
+
+								if (expected.content) {
+									return response
+										.text()
+										.then(function (text) {
+											if (text !== expected.content) {
+												if (failures.indexOf('bad content: ' + text) === -1) {
+													failures.push('bad content: ' + text);
+												}
+												reject();
+											} else {
+												resolve();
+											}
+										});
+								}
+
+								resolve();
+							})
+								.then(function () {
+									end(baseUrl + url + ' responded as expected');
 								});
 
-								if (badHeaders.length) {
-									badHeaders = badHeaders.map(function (header) {
-										return header + ':' + response.headers.get(header);
-									}).join('; ');
-
-									if (failures.indexOf('bad headers: ' + badHeaders) === -1) {
-										failures.push('bad headers: ' + badHeaders);
-									}
-									return reject();
-								}
-							}
-
-							if (expected.content) {
-								return response
-									.text()
-									.then(function (text) {
-										if (text !== expected.content) {
-											if (failures.indexOf('bad content: ' + text) === -1) {
-												failures.push('bad content: ' + text);
-											}
-											reject();
-										} else {
-											resolve();
-										}
-									});
-							}
-
-							resolve();
 						})
-							.then(function () {
-								end(baseUrl + url + ' responded as expected');
-							});
+						.catch(function(err) {
+							if (err.message.indexOf('timeout') > -1 ) {
+								failures.push('endpoint too slow');
+							}
+						});
+				}
+				checker = setInterval(checkGtg, 3000);
+				timeout = setTimeout(function() {
+					console.log(baseUrl + url + ' keeps failing with: ' + failures.join(', '));
+					reject('Test url polling failed');
+					clearInterval(checker);
+				}, 2*60*1000);
+			});
 
-					})
-					.catch(function(err) {
-						if (err.message.indexOf('timeout') > -1 ) {
-							failures.push('endpoint too slow');
-						}
-					});
-			}
-			checker = setInterval(checkGtg, 3000);
-			timeout = setTimeout(function() {
-				console.log(baseUrl + url + ' keeps failing with: ' + failures.join(', '));
-				reject('Test url polling failed');
-				clearInterval(checker);
-			}, 2*60*1000);
-		});
+		};
 
-	}));
+	});
+
+	return new Directly(10, fetchers);
+
 }
 
 


### PR DESCRIPTION
Originally the `test-url` task was passing an array of fetches to `Promise.all` which in turn will fire all of the network requests at once. As the array could potentially be very large this was causing weird issues and requests to fail/timeout. 

This PR simply refactors the task to use @wheresrhys `Directly` promise throttle library and spread the requests out in batches of 10.

This seems to make the `next-article` tests pass: https://circleci.com/gh/Financial-Times/next-article/447

/cc @adambraimbridge @matthew-andrews 