### PR TITLE
Add --serves option to rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     download-development-keys [options]                 downloads development environment variables from next-config-vars and stores them in your home directory if a file doesn't already exist
     scale [options] [source] [target]                   downloads process information from next-service-registry and scales/sizes the application servers
     provision [app]                                     provisions a new instance of an application server
-    verify [options]                                    internally calls origami-build-tools verify with some Next specific configuration (use only for APPLICATIONS.  Front End components should continue to use origami-build-tools verify)
+    verify [options]                                    internally calls origami-build-tools verify with some Next specific configuration (use only for APPLICATIONS. Front End components should continue to use origami-build-tools verify)
     nightwatch [options] [test]                         runs nightwatch with some sensible defaults
     deploy-hashed-assets                                deploys hashed asset files to S3 (if AWS keys set correctly)
     build [options]                                     build javascript and css
@@ -23,7 +23,7 @@
     run [options]                                       Runs the local app through the router
     about                                               Creates an __about.json file for the app
     deploy-static [options] <source> [otherSources...]  Deploys static <source> to [destination] on S3 (where [destination] is a full S3 URL).  Requires AWS_ACCESS and AWS_SECRET env vars
-    rebuild [apps...]                                   Trigger a rebuild of the latest master on Circle
+    rebuild [options] [apps...]                         Trigger a rebuild of the latest master on Circle
     wait-for-gtg <app>                                  Polls the /__gtg endpoint of a given app until it returns 200
     ingest [uuid...]                                    [Re-]ingest content into the Elastic Search cache [api v1 only]
     *                                                   

--- a/bin/next-build-tools.js
+++ b/bin/next-build-tools.js
@@ -259,10 +259,12 @@ program
 
 program
 	.command('rebuild [apps...]')
+	.option('--serves <type>', 'Trigger rebuilds of apps where type is served.')
 	.description('Trigger a rebuild of the latest master on Circle')
-	.action(function(apps) {
+	.action(function(apps, opts) {
 		return rebuild({
-			apps: apps
+			apps: apps,
+			serves: opts.serves
 		}).catch(exit);
 	});
 

--- a/tasks/rebuild.js
+++ b/tasks/rebuild.js
@@ -43,6 +43,7 @@ function lastMasterBuild(project) {
 
 module.exports = function(options) {
 	var apps = options.apps;
+	var serves = options.serves;
 
 	return keys()
 		.then(function(env) {
@@ -52,7 +53,11 @@ module.exports = function(options) {
 					.then(fetchres.json)
 					.then(function(data) {
 						apps = data
-							.filter(function(apps) { return apps.versions['1'] || apps.versions['2']; })
+							.filter(function(app) {
+								if (serves) { return app.serves && app.serves.indexOf(serves) > -1; }
+								return true;
+							})
+							.filter(function(app) { return app.versions['1'] || app.versions['2']; })
 							.map(function(app) {
 								var repo;
 								Object.keys(app.versions).forEach(function(version) {


### PR DESCRIPTION
Trigger rebuilds for apps based on the `serves` property listed in the `next-registry`. Useful for rebuilding a subset of apps upon release of a shared component.