### PR TITLE
make smoke tests run consecutively

### DIFF
--- a/tasks/test-urls.js
+++ b/tasks/test-urls.js
@@ -146,7 +146,7 @@ function testUrls (opts) {
 	var fetchers = Object.keys(opts.urls).map(function (url) {
 		return new UrlTest(baseUrl + url, opts.headers, opts.urls[url], opts.timeout).runner();
 	});
-	return directly(5, fetchers);
+	return directly(1, fetchers);
 }
 
 


### PR DESCRIPTION
On article smoke tests are frequently falling over with Heroku backlog too deep (H11), causing issues with build reliability. Suggest reducing the directly number to 1 to run the smoke tests consecutively. This will also aid debugging as will see which URL fails.