### PR TITLE
Relax the rules on `eslint`'s environment — by allowing browser JavaScript

### DIFF
--- a/config/eslint.json
+++ b/config/eslint.json
@@ -1,5 +1,6 @@
 {
   "env": {
+  	"browser": true,
 	"es6": true,
   	"mocha": true,
 	"node": true


### PR DESCRIPTION
@Lrnk 