### PR TITLE
adds ability to run eslint fix via nbt verify

### DIFF
--- a/bin/next-build-tools.js
+++ b/bin/next-build-tools.js
@@ -137,12 +137,14 @@ program
 	.option('--skip-layout-checks', 'run verify checks when the application doesn\'t have customer facing html pages')
 	.option('--skip-npm-checks', 'skip npm dependency checks')
 	.option('--skip-dotenv-check', 'skip checking `.gitignore` has `.env` in it')
+	.option('--fix', 'eslint will fix any errors it finds. Will also skip all non linty checks')
 	.description('internally calls origami-build-tools verify with some Next specific configuration (use only for APPLICATIONS. Front End components should continue to use origami-build-tools verify)')
 	.action(function(opts) {
 		verify({
 			skipLayoutChecks: opts.skipLayoutChecks,
 			skipNpmChecks: opts.skipNpmChecks,
-			skipDotenvCheck: opts.skipDotenvCheck
+			skipDotenvCheck: opts.skipDotenvCheck,
+			fix: opts.fix
 		}).catch(exit);
 	});
 

--- a/tasks/verify.js
+++ b/tasks/verify.js
@@ -6,6 +6,7 @@ var path = require('path');
 var verifyLayoutDeps = require('../lib/verify-layout-deps');
 var verifyNpmDeps = require('../lib/verify-npm-deps');
 var verifyDotenvInGitignore = require('../lib/verify-dotenv-in-gitignore');
+var doFix = false;
 
 function obtVerify() {
 	return new Promise(function(resolve, reject) {
@@ -17,23 +18,32 @@ function obtVerify() {
 
 gulp.task('verify', function() {
 	return origamiBuildTools.verify(gulp, {
-			esLintPath: path.join(__dirname, '..', 'config', 'eslint.json')
+			esLintPath: path.join(__dirname, '..', 'config', 'eslint.json'),
+			fix: doFix
 		});
 });
 
 module.exports = function(opts) {
+
+	// should not be possible to run with --fix flag in CI
+	if (opts.fix && (process.env.CI || process.env.JENKINS_URL)) {
+		throw 'nbt verify should not be called with --fix in CI';
+	}
+
+	doFix = opts.fix;
+
 	var checks = [
 		obtVerify()
 	];
-	if (!opts.skipNpmChecks) {
+	if (!opts.skipNpmChecks && !opts.fix) {
 		verifyNpmDeps();
 	}
 
-	if (!opts.skipLayoutChecks) {
+	if (!opts.skipLayoutChecks && !opts.fix) {
 		checks.push(verifyLayoutDeps({ layout: opts.layout }));
 	}
 
-	if (!opts.skipDotenvCheck) {
+	if (!opts.skipDotenvCheck && !opts.fix) {
 		checks.push(verifyDotenvInGitignore());
 	}
 	return Promise.all(checks);


### PR DESCRIPTION
To make it easier to upgrade repos from es5 to es6 `nbt verify --fix` can be called to auto fix warnings and errors