### PR TITLE
fixed post smoke requests

### DIFF
--- a/tasks/test-urls.js
+++ b/tasks/test-urls.js
@@ -139,14 +139,14 @@ class UrlTest {
 
 
 	getRedirect () {
-		let curl = `curl -s '${this.url}' -I`;
+		let curl = `curl -s '${this.url}' -D-`;
 
 		if (this.method) {
 			curl += ` -X ${this.method}`;
 		}
 
 		if (this.body) {
-			curl += ` -d '${this.body}'`;
+			curl += ` -d '${JSON.stringify(this.body)}'`;
 		}
 
 		if (this.headers) {


### PR DESCRIPTION
`-I` and `-d` params are incompatible (attempts to send a request for the headers and a separate one for the post)

`-D-` has the same effect as `-I` as far as nbt is concerned

(http://stackoverflow.com/a/287299)