### PR TITLE
Set outbound cache metadata

### DIFF
--- a/tasks/deploy-hashed-assets.js
+++ b/tasks/deploy-hashed-assets.js
@@ -60,14 +60,17 @@ module.exports = app => {
 			const extension = path.extname(file).substring(1);
 
 			console.log(`sending ${key} to S3`);
-			
+
 			return readFile(path.join(process.cwd(), 'public', file))
 				.then(content => {
 					let params = {
 						Key: key,
 						Body: content,
 						ACL: 'public-read',
-						CacheControl: 'public, max-age=31536000'
+						CacheControl: 'public, max-age=31536000',
+						Metadata: {
+							'outbound-cache-control': 'public, max-age=31536000'
+						}
 					};
 					switch(extension) {
 						case 'js':

--- a/tasks/deploy-static.js
+++ b/tasks/deploy-static.js
@@ -46,12 +46,16 @@ module.exports = function(opts) {
 
 				console.log("About to upload " + file + " to " + key);
 				return new Promise(function(resolve, reject) {
+					const cacheControl = opts.cacheControl || (opts.cache ? 'public, max-age=31536000' : undefined);
 					s3bucket.upload({
 						Key: key,
 						ContentType: opts.contentType || determineContentType(file),
 						ACL: 'public-read',
 						Body: content,
-						CacheControl: opts.cacheControl || (opts.cache ? 'public, max-age=31536000' : undefined)
+						CacheControl: cacheControl,
+						Metadata: {
+							'outbound-cache-control': cacheControl
+						}
 					}, function(err, data) {
 						if (err) {
 							reject(err);


### PR DESCRIPTION
Which will produce a header of the format `x-amz-meta-outbound-cache-control: ...`

See http://git.svc.ft.com/projects/NEXT/repos/fastly-config/pull-requests/100/overview