### PR TITLE
fix git tag sort

### DIFF
--- a/tasks/bottle.js
+++ b/tasks/bottle.js
@@ -14,7 +14,7 @@ const getLatestTag = () => {
 		.then(tagList => {
 			const latest = tagList.split('\n')
 				.filter(semver.valid)
-				.sort(semver.gt)
+				.sort(semver.compare)
 				.pop()
 
 			return latest ? latest.replace(/^v/, '') : null;


### PR DESCRIPTION
`semver.gt` returns a boolean. swap for `semver.compare` which returns -1, 0 or 1, and will work as a comparator function
@wheresrhys 