### PR TITLE
Be able to override the entry path to Sass/Js compilation

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -97,7 +97,7 @@ gulp.task('build-worker', function() {
 });
 
 
-function task (opts) {
+function task(opts) {
 	isDev = opts.isDev;
 	let tasks = [];
 	if (!opts.skipSass) {
@@ -111,7 +111,7 @@ function task (opts) {
 	}
 	return Promise.all([
 			run(tasks, opts),
-			about()
+			opts.skipAbout || about()
 		])
 		.then(() => {
 			if (!opts.isDev) {
@@ -119,7 +119,7 @@ function task (opts) {
 			}
 		})
 		.then(() => {
-			if (!opts.isDev) {
+			if (!opts.isDev && !opts.skipHaikro) {
 				console.log("Building the Heroku tarball");
 				return build({ project: process.cwd() });
 			}
@@ -135,9 +135,19 @@ module.exports = function (program, utils) {
 		.option('--watch-files-sass <globs>', `Comma separated globs of sass files to watch [${watchFiles.sass}]`, watchFiles.sass)
 		.option('--skip-js', 'skips compilation of JavaScript')
 		.option('--skip-sass', 'skips compilation of Sass')
+		.option('--skip-about', 'skips generation of about json')
+		.option('--skip-haikro', 'skips Haikro build')
+		.option('--main-js [filename]', 'overrides the main js file')
+		.option('--main-sass [filename]', 'overrides the main sass file')
 		.option('--worker', 'additionally builds Service Worker JavaScript')
 		.description('build javascript and css')
 		.action(function(options) {
+			if (options.mainScss) {
+				mainScssFile = options.mainScss;
+			}
+			if (options.mainJs) {
+				mainJsFile = options.mainJs;
+			}
 			task({
 				isDev: options.dev,
 				watch: options.watch,
@@ -145,6 +155,8 @@ module.exports = function (program, utils) {
 				watchFilesSass: options.watchFilesSass,
 				skipJs: options.skipJs,
 				skipSass: options.skipSass,
+				skipAbout: options.skipAbout,
+				skipHaikro: options.skipHaikro,
 				worker: options.worker
 			}).catch(utils.exit);
 		});

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -114,7 +114,7 @@ function task(opts) {
 			opts.skipAbout || about()
 		])
 		.then(() => {
-			if (!opts.isDev) {
+			if (!opts.isDev && !opts.skipHash) {
 				return hashAssets();
 			}
 		})
@@ -137,6 +137,7 @@ module.exports = function (program, utils) {
 		.option('--skip-sass', 'skips compilation of Sass')
 		.option('--skip-about', 'skips generation of about json')
 		.option('--skip-haikro', 'skips Haikro build')
+		.option('--skip-hash', 'skips asset hashing json file compilation')
 		.option('--main-js [filename]', 'overrides the main js file')
 		.option('--main-sass [filename]', 'overrides the main sass file')
 		.option('--worker', 'additionally builds Service Worker JavaScript')
@@ -157,6 +158,7 @@ module.exports = function (program, utils) {
 				skipSass: options.skipSass,
 				skipAbout: options.skipAbout,
 				skipHaikro: options.skipHaikro,
+				skipHash: options.skipHash,
 				worker: options.worker
 			}).catch(utils.exit);
 		});


### PR DESCRIPTION
Enables @commuterjoy to easily compile separate JS/CSS files.  Includes the delightful new option `--skip-about`.

To build a file located in `client/mattc.js` in the `build-production` step run:-

```sh
$ nbt build --main-js mattc.js --skip-sass --skip-about --skip-haikro --skip-hash
```

And in the `make build` step it's the same with `--dev` added:-

```sh
$ nbt build --main-js mattc.js --skip-sass --skip-about --skip-haikro --skip-hash --dev
```

I think in the next major version of NBT I should switch the logic to be opt-in rather than opt-out :grin:.