### PR TITLE
allow running as https

### DIFF
--- a/tasks/run.js
+++ b/tasks/run.js
@@ -101,32 +101,17 @@ function runRouter(opts) {
 		PORT: opts.PORT
 	};
 
-	var https = false;
-
-	// for HTTPS we expect subargs as [--https,path/to/cert.pem,path/to/key.pem]
-	if (opts.subargs) {
-		
-		var args = opts.subargs.replace(/^\[/, '').replace(/]$/, '').split(',');
-
-		var https = args.length && args[0].indexOf('https') !== -1 ? args[0] : false;
-
-		// If https, check if the user provided a certificate and key
-		if (https) {
-			envVars.HTTPS = https;
-
-			// Only use the cert/key in the arguments if both provided
-			// Fallback to defaults if not
-			if (args.length > 2) {
-				envVars.CERT = args[1];
-				envVars.CERT_KEY = args[2];
-			}
-		}
+	// Only use the cert/key in the arguments if both provided
+	// Fallback to defaults if not
+	if (opts.https && opts.cert && opts.key) {
+		envVars.CERT = opts.cert;
+		envVars.CERT_KEY = opts.key;
 	}
 
 	envVars[normalizeName(packageJson.name, { version: false })] = opts.localPort;
 	return configureAndSpawn(envVars, function (env) {
 
-		var bin = https ? 'next-router-https' : 'next-router';
+		var bin = opts.https ? 'next-router-https' : 'next-router';
 		return [bin, { env: env }];
 	});
 }
@@ -156,7 +141,7 @@ function task (opts) {
 					.then(function() {
 						return Promise.all([
 							runLocal({ PORT: localPort, harmony: opts.harmony, debug: opts.debug, nodemon: opts.nodemon }),
-							runRouter({ PORT: 5050, localPort: localPort, harmony: opts.harmony, subargs: opts.subargs })
+							runRouter({ PORT: 5050, localPort: localPort, harmony: opts.harmony, https: opts.https, cert: opts.cert, key: opts.key })
 						]);
 					});
 			}
@@ -174,6 +159,9 @@ module.exports = function (program, utils) {
 		.option('-s, --script <file>', 'Runs a single javascript file')
 		.option('--subargs [subargs]', 'Sub arguments to pass to a single script', /^\[.+]$/)
 		.option('--no-nodemon', 'Do not run through nodemon')
+		.option('--https', 'Run with HTTPS')
+		.option('--cert <file>', 'Specify a certificate to use with HTTPS. Use with --https.')
+		.option('--key <file>', 'Specify a certificate key to use with HTTPS. Use with --https.')
 		.action(function(opts){
 			task(opts).catch(utils.exit);
 		});


### PR DESCRIPTION
Allow alternative rule for running as https by passing subargs options to the proxy, i.e.
```
run:
	export DEBUG=ft-next-signup-debug; \
	nbt run --harmony
run-https: 
	export DEBUG=ft-next-signup-debug; \
	nbt run --harmony --subargs [--https,key.pem,key-cert.pem]
```

cc/ @matthew-andrews @wheresrhys 

Relevant router update in:
http://git.svc.ft.com/projects/NEXT/repos/router/pull-requests/67/diff#server/proxy.js

cc/ @ifyio This is what we need to run https://local.ft.com/signup to integrate with the Zuora iframe 