### PR TITLE
Allow custom `nbt run` script without sacrificing runRouter()

### DIFF
--- a/tasks/run.js
+++ b/tasks/run.js
@@ -51,7 +51,7 @@ function runLocal(opts) {
 		if(opts.script) {
 			args.push(opts.script);
 		} else {
-			args.push('server/app.js');
+			args.push(packageJson.main || 'server/app.js');
 		}
 
 		if (opts.harmony) {


### PR DESCRIPTION
The node entry point for next-myft-page is now `server/init.js`, which pulls in `server/app.js` (seems sensible). However, `nbt run` has a hard-coded entry point of `server/app.js`.

(The next-front-page app also has this setup but the names are the wrong way round, presumably because of this issue.)

This PR allows setting a custom script (e.g. `server/init.js`) without having to use the `--script` option, which doesn’t call `runRouter()`.

Prerequisite PRs attached (these had invalid entry points in their `package.json`s).